### PR TITLE
Include stdint.h header to fix compilation on linux

### DIFF
--- a/talk32.c
+++ b/talk32.c
@@ -15,6 +15,7 @@
 #include <sys/select.h>
 #include <sys/stat.h>
 #include <ctype.h>
+#include <stdint.h>
 
 #define CTRL_A "\x01"   // Enter raw REPL mode.
 #define CTRL_B "\x02"   // Exit raw REPL mode.


### PR DESCRIPTION
I tried both gcc and clang first but to compile talk32 on linux I need to include `stdint.h` header on linux. My system has gcc 12.2.0 and clang 14.0.6.

Without that include gcc provides this very detailed error:
```
❯ make      
cc -Wall -W -O2 -o talk32 talk32.c
talk32.c: In function ‘get_command’:
talk32.c:542:5: error: unknown type name ‘uint32_t’
  542 |     uint32_t left_len;
      |     ^~~~~~~~
talk32.c:18:1: note: ‘uint32_t’ is defined in header ‘<stdint.h>’; did you forget to ‘#include <stdint.h>’?
   17 | #include <ctype.h>
  +++ |+#include <stdint.h>
   18 | 
talk32.c:554:9: error: unknown type name ‘uint32_t’
  554 |         uint32_t read_len = sizeof(buf);
      |         ^~~~~~~~
talk32.c:554:9: note: ‘uint32_t’ is defined in header ‘<stdint.h>’; did you forget to ‘#include <stdint.h>’?
make: *** [Makefile:2: talk32] Error 1
```

Please tell me if you prefer an `#ifdef __linux__` conditional include for `stdint.h` header.